### PR TITLE
make compatible with Python 2.6

### DIFF
--- a/bin/check_megacli
+++ b/bin/check_megacli
@@ -16,7 +16,7 @@ UNKNOWN = 3
 
 
 def main():
-    CHECKS = {'PD', 'LD', 'BBU'}
+    CHECKS = ('PD', 'LD', 'BBU')
 
     parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
Set literals are a Python 2.7 feature. I believe that the entire rest of the library is 2.6-compatible.
